### PR TITLE
Dead download link replacement for x64dbg

### DIFF
--- a/dynamic-tools.json
+++ b/dynamic-tools.json
@@ -4,7 +4,7 @@
 {"name": "DbgChild", "url": "https://github.com/David-Reguera-Garcia-Dreg/DbgChild/releases/download/beta10/DbgChild.Beta.10.zip", "nonCommercial": true, "manual": false},
 {"name": "Everything", "url":"https://www.voidtools.com/Everything-1.4.1.1005.x64-Setup.exe", "nonCommercial": true, "manual": false},
 {"name": "HxD", "url":"https://mh-nexus.de/downloads/HxDPortableSetup.zip", "nonCommercial": true, "manual": false},
-{"name": "LordPE", "url": "https://ro.softpedia-secure-download.com/dl/12bb77dc124e1532766993e8af27362c/60291ad7/100000029/software/PROGRAMMING/lordpe.zip", "nonCommercial": false, "manual": false},
+{"name": "LordPE", "url": "https://ro.softpedia-secure-download.com/dl/9c123e77c021400cb155499796078f45/60320772/100000029/software/PROGRAMMING/lordpe.zip", "nonCommercial": false, "manual": false},
 {"name": "NetworkMiner", "url": "https://www.netresec.com/?download=NetworkMiner", "nonCommercial": false, "manual": true},
 {"name": "ODbgScriptv2", "url": "https://master.dl.sourceforge.net/project/odbgsrcriptv202/ODbgScript203-bin%2802-01-2016%29.7z", "nonCommercial": true, "manual": false},
 {"name": "OllyDbg", "url": "http://www.ollydbg.de/odbg201.zip", "nonCommercial": false, "manual": false},
@@ -22,7 +22,7 @@
 {"name": "VMwareCloak", "url": "https://github.com/d4rksystem/VMwareCloak/archive/main.zip", "nonCommercial": false, "manual": true},
 {"name": "WinSCP", "url": "https://winscp.net/download/WinSCP-5.17.10-Setup.exe", "nonCommercial": true, "manual": false},
 {"name": "Wireshark", "url": "https://1.eu.dl.wireshark.org/win64/Wireshark-win64-3.4.3.exe", "nonCommercial": true, "manual": false},
-{"name": "x64dbg", "url": "https://github.com/x64dbg/x64dbg/releases/download/snapshot/snapshot_2021-02-09_17-28.zip", "nonCommercial": true, "manual": false},
+{"name": "x64dbg", "url": "https://github.com/x64dbg/x64dbg/releases/download/snapshot/snapshot_2021-02-15_22-35.zip", "nonCommercial": true, "manual": false},
 {"name": "xAnalyzer x86", "url": "https://github.com/ThunderCls/xAnalyzer/releases/download/2.5.5/xAnalyzer.dp32", "nonCommercial": true, "manual": false},
 {"name": "xAnalyzer x64", "url": "https://github.com/ThunderCls/xAnalyzer/releases/download/2.5.5/xAnalyzer.dp64", "nonCommercial": true, "manual": false},
 {"name": "xAnalyzer apis_def", "url": "https://github.com/ThunderCls/xAnalyzer/releases/download/2.5.5/apis_def.zip", "nonCommercial": true, "manual": false}]


### PR DESCRIPTION
snapshot_2021-02-09_17-28.zip is not available anymore on the repo https://github.com/x64dbg/x64dbg.